### PR TITLE
Catch signals and exit immediately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,5 @@ ADD index.html /www/index.html
 
 EXPOSE 8000
 
-# Create a basic webserver and sleep forever
-CMD httpd -p 8000 -h /www; tail -f /dev/null
-
+# Create a basic webserver and run it until the container is stopped 
+CMD trap "exit 0;" TERM INT; httpd -p 8000 -h /www -f & wait


### PR DESCRIPTION
This change allows the container to exit immediately after the request (docker stop, kill, etc).

Shell ignored SIGTERM from Docker before this change, which resulted in slow killing of the container via SIGKILL (after some timeout has passed).
Also removed tail and used foreground option of the httpd binary.