### PR TITLE
Add port from environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM busybox:latest
+ENV PORT=8000
 LABEL maintainer="Chris <c@crccheck.com>"
 
 ADD index.html /www/index.html
 
-EXPOSE 8000
-HEALTHCHECK CMD nc -z localhost 8000
+# EXPOSE $PORT
+
+HEALTHCHECK CMD nc -z localhost $PORT
 
 # Create a basic webserver and run it until the container is stopped
-CMD trap "exit 0;" TERM INT; httpd -p 8000 -h /www -f & wait
+CMD trap "exit 0;" TERM INT; httpd -p $PORT -h /www -f & wait


### PR DESCRIPTION
Nice tiny image! In my podman setup I need to be able to assign each a different port, so this adds the option to run with a PORT environment variable, specifying the internal port to listen on.